### PR TITLE
Remove unused JSON module from level manager

### DIFF
--- a/scripts/level_manager.script
+++ b/scripts/level_manager.script
@@ -1,6 +1,5 @@
 local globals = require "scripts.globals"
 local util = require "scripts.util"
-local json = require "json"
 
 local LEVELS = {
     level1 = require "levels.level1",


### PR DESCRIPTION
## Summary
- remove unused `json` require from level manager script

## Testing
- `luacheck scripts/level_manager.script` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fabd66cf08329bcb56dd40a67efa9