### PR TITLE
Remove build and .internal directories from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ build/
 # Archives
 *.zip
 
-# Editor caches
+# Editor caches and internal directories
 **/.cpcache/
 **/.internal/
 


### PR DESCRIPTION
## Summary
- Ensure build output and internal cache directories are ignored.

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fb5b518dc832986877e04dd8e3a66